### PR TITLE
Fix Table Sorting

### DIFF
--- a/src/data/map.js
+++ b/src/data/map.js
@@ -467,12 +467,27 @@ async function getRaids(filter) {
                     (utils.inArray(filter.city, city) || filter.city.toLowerCase() === 'all')) {
                     const mapLink = util.format(config.google.maps, row.lat, row.lon);
                     raids.push({
-                        pokemon: `<img src='${imgUrl}' width=auto height=32 />&nbsp;${name}`,
-                        raid_starts: startTime,
-                        raid_ends: endTime,
-                        raid_level: level === 6 ? 'Mega' : 'Level ' + level,
+                        pokemon: {
+                            formatted: `<img src='${imgUrl}' width=auto height=32 />&nbsp;${name}`,
+                            sort: row.raid_pokemon_id
+                        },
+                        raid_starts: {
+                            formatted: startTime,
+                            sort: starts
+                        },
+                        raid_ends: {
+                            formatted: endTime,
+                            sort: ends
+                        },
+                        raid_level: {
+                            formatted: parseInt(level) === 6 ? 'Mega' : 'Level ' + level,
+                            sort: level
+                        },
                         gym_name: `<a href='${mapLink}' target='_blank'>${gym}</a>`,
-                        team: teamIcon,
+                        team: {
+                            formatted: teamIcon,
+                            sort: row.team_id
+                        },
                         ex_eligible: ex,
                         city: city
                     });
@@ -522,9 +537,18 @@ async function getGyms(filter) {
                 const mapLink = util.format(config.google.maps, row.lat, row.lon);
                 gyms.push({
                     name: `<a href='${mapLink}' target='_blank'>${name}</a>`,
-                    team: teamIcon,
-                    available_slots: slots,
-                    guarding_pokemon_id: pkmnIcon === 'None' ? 'None' : `<img src='${pkmnIcon}' width=auto height=32 />&nbsp;${guard}`,
+                    team: {
+                        formatted: teamIcon,
+                        sort: row.team_id
+                    },
+                    available_slots: {
+                        formatted: slots,
+                        sort: row.availble_slots
+                    },
+                    guarding_pokemon_id: {
+                        formatted: pkmnIcon === 'None' ? 'None' : `<img src='${pkmnIcon}' width=auto height=32 />&nbsp;${guard}`,
+                        sort: row.guarding_pokemon_id
+                    },
                     in_battle: inBattle,
                     city: city
                     // TODO: Updated
@@ -623,8 +647,8 @@ async function getInvasions(filter) {
                     grunt_type: `<img src='./img/grunts/${row.grunt_type}.png' width=auto height=32 />&nbsp;${gruntType}`,
                     pokestop_name: `<a href='${mapLink}' target='_blank'>${name}</a>`,
                     expires: { 
-                        "formatted": expires,
-                        "sort": row.incident_expire_timestamp
+                        formatted: expires,
+                        sort: row.incident_expire_timestamp
                     },
                     city: city
                     // TODO: Updated

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -470,7 +470,7 @@ async function getRaids(filter) {
                         pokemon: `<img src='${imgUrl}' width=auto height=32 />&nbsp;${name}`,
                         raid_starts: startTime,
                         raid_ends: endTime,
-                        raid_level: 'Level ' + level,
+                        raid_level: level === 6 ? 'Mega' : 'Level ' + level,
                         gym_name: `<a href='${mapLink}' target='_blank'>${gym}</a>`,
                         team: teamIcon,
                         ex_eligible: ex,

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -622,7 +622,10 @@ async function getInvasions(filter) {
                 invasions.push({
                     grunt_type: `<img src='./img/grunts/${row.grunt_type}.png' width=auto height=32 />&nbsp;${gruntType}`,
                     pokestop_name: `<a href='${mapLink}' target='_blank'>${name}</a>`,
-                    expires: expires,
+                    expires: { 
+                        "formatted": expires,
+                        "sort": row.incident_expire_timestamp
+                    },
                     city: city
                     // TODO: Updated
                 });

--- a/src/data/map.js
+++ b/src/data/map.js
@@ -255,10 +255,19 @@ async function getShinyRates(filter) {
             const rate = shiny === 0 || total === 0 ? 0 : Math.round(total / shiny);
             const imageUrl = locale.getPokemonIcon(pokemonId, 0);
             data.push({
-                id: `#${pokemonId}`,
+                id: {
+                    formatted: `#${pokemonId}`,
+                    sort: pokemonId
+                },
                 pokemon: `<img src="${imageUrl}" width="auto" height="32" />&nbsp;${name}`,
-                rate: `1/${rate}`,
-                count: `${shiny.toLocaleString()}/${total.toLocaleString()}`
+                rate: {
+                    formatted: `1/${rate}`,
+                    sort: rate
+                },
+                count: {
+                    formatted: `${shiny.toLocaleString()}/${total.toLocaleString()}`,
+                    sort: total
+                }
             });
         }
         return data;

--- a/src/views/gyms.mustache
+++ b/src/views/gyms.mustache
@@ -170,11 +170,23 @@
             "pageLength": 100,
             "columns": [
                 { "data": "name" },
-                { "data": "team" },
-                { "data": "available_slots" },
-                { "data": "guarding_pokemon_id" },
+                { data: {
+                    _: "team.formatted",
+                    sort: "team.sort"
+                } },
+                { data: {
+                    _: "available_slots.formatted",
+                    sort: "available_slots.sort"
+                } },
+                { data: {
+                    _: "guarding_pokemon_id.formatted",
+                    sort: "guarding_pokemon_id.sort"
+                } },
                 { "data": "in_battle" },
                 { "data": "city" }
+            ],
+            "columnDefs": [
+                { type: 'formatted-num', targets: [1, 2, 3] }
             ],
             "info": true,
             "order": [[ 0, "asc" ]],

--- a/src/views/invasions.mustache
+++ b/src/views/invasions.mustache
@@ -179,9 +179,15 @@
             "columns": [
                 { "data": "grunt_type" },
                 { "data": "pokestop_name" },
-                { "data": "expires" },
+                { data: {
+                    _: "expires.formatted",
+                    sort: "expires.sort"
+                } },
                 { "data": "city" }
             ],
+        "columnDefs": [
+            { type: 'formatted-num', targets: [2] }
+        ],
             "info": true,
             "order": [[ 2, "asc" ]],
             "search.caseInsensitive": true,

--- a/src/views/pokemon.mustache
+++ b/src/views/pokemon.mustache
@@ -481,10 +481,22 @@
         "lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
         "pageLength": 100,
         "columns": [
-            { "data": "id" },
+            { data: {
+                _: "id.formatted",
+                sort: "id.sort"
+            } },
             { "data": "pokemon" },
-            { "data": "rate" },
-            { "data": "count" },
+            { data: {
+                _: "rate.formatted",
+                sort: "rate.sort"
+            } },
+            { data: {
+                _: "count.formatted",
+                sort: "count.sort"
+            } },
+        ],
+        "columnDefs": [
+            { type: 'formatted-num', targets: [0, 2, 3] }
         ],
         "info": true,
         "order": [[ 0, "asc" ]],

--- a/src/views/raids.mustache
+++ b/src/views/raids.mustache
@@ -223,14 +223,32 @@
             "lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
             "pageLength": 100,
             "columns": [
-                { "data": "pokemon" },
-                { "data": "raid_level" },
-                { "data": "raid_starts" },
-                { "data": "raid_ends" },
+                { data: {
+                    _: "pokemon.formatted",
+                    sort: "pokemon.sort"
+                } },
+                { data: {
+                    _: "raid_level.formatted",
+                    sort: "raid_level.sort"
+                } },
+                { data: {
+                    _: "raid_starts.formatted",
+                    sort: "raid_starts.sort"
+                } },
+                { data: {
+                    _: "raid_ends.formatted",
+                    sort: "raid_ends.sort"
+                } },
                 { "data": "gym_name" },
-                { "data": "team" },
+                { data: {
+                    _: "team.formatted",
+                    sort: "team.sort"
+                } },
                 { "data": "ex_eligible" },
                 { "data": "city" }
+            ],
+            "columnDefs": [
+                { type: 'formatted-num', targets: [0, 1, 2, 3, 5] }
             ],
             "info": true,
             "order": [[ 3, "asc" ]],


### PR DESCRIPTION
Fix: #19 
Fix: #20 

Fixes table sorting for the following:
- Shiny stats
- Raids
- Gyms
- Invasions