### PR TITLE
remove substitute pokemon from gym defenders list

### DIFF
--- a/src/data/map.js
+++ b/src/data/map.js
@@ -714,6 +714,7 @@ async function getGymDefenders(limit = 10) {
     const sql = `
 	SELECT guarding_pokemon_id, COUNT(guarding_pokemon_id) AS count
 	FROM gym
+	WHERE guarding_pokemon_id != 0
 	GROUP BY guarding_pokemon_id
 	ORDER BY count DESC
 	LIMIT ?


### PR DESCRIPTION
adjust query to eliminate the substitute pokemon being displayed due to team neutral gyms.